### PR TITLE
btt_skr_mini_e3_v2.0 builds with latest PlatformIO extension.

### DIFF
--- a/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/Marlin/Configuration.h
+++ b/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/Marlin/Configuration.h
@@ -145,7 +145,7 @@
 #endif
 
 // Name displayed in the LCD "Ready" message and Info menu
-#define CUSTOM_MACHINE_NAME "Ender-3"
+#define CUSTOM_MACHINE_NAME "AHE Machine"
 
 // Printer's unique ID, used by some programs to differentiate between machines.
 // Choose your own or use a service like https://www.uuidgenerator.net/version4
@@ -812,14 +812,14 @@
  * Override with M92
  *                                      X, Y, Z, E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 400, 93 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 400, 400, 400, 93 }
 
 /**
  * Default Max Feed Rate (mm/s)
  * Override with M203
  *                                      X, Y, Z, E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 200, 200, 5, 25 }
+#define DEFAULT_MAX_FEEDRATE          { 1500, 1500, 5, 25 }
 
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)
@@ -832,7 +832,7 @@
  * Override with M201
  *                                      X, Y, Z, E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_ACCELERATION      { 1000, 1000, 100, 5000 }
+#define DEFAULT_MAX_ACCELERATION      { 1500, 1500, 100, 5000 }
 
 //#define LIMITED_MAX_ACCEL_EDITING     // Limit edit via M201 or LCD to DEFAULT_MAX_ACCELERATION * 2
 #if ENABLED(LIMITED_MAX_ACCEL_EDITING)
@@ -1238,8 +1238,8 @@
 // @section machine
 
 // The size of the printable area
-#define X_BED_SIZE 235
-#define Y_BED_SIZE 235
+#define X_BED_SIZE 1000
+#define Y_BED_SIZE 1000
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 #define X_MIN_POS 0
@@ -1247,7 +1247,7 @@
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE
-#define Z_MAX_POS 250
+#define Z_MAX_POS 1000
 
 /**
  * Software Endstops

--- a/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/buildroot/share/PlatformIO/ldscripts/STM32F103RC_SKR_MINI_256K.ld
+++ b/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/buildroot/share/PlatformIO/ldscripts/STM32F103RC_SKR_MINI_256K.ld
@@ -1,7 +1,8 @@
 MEMORY
 {
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K - 40
-  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 256K - 28K - 4K
+  rom (rx)  : ORIGIN = 0x08000000, LENGTH = 256K - 40
+  /* rom (rx)  : ORIGIN = 0x08007000, LENGTH = 256K - 28K - 4K */
 }
 
 /* Provide memory region aliases for common.inc */

--- a/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/buildroot/share/PlatformIO/scripts/marlin.py
+++ b/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/buildroot/share/PlatformIO/scripts/marlin.py
@@ -17,10 +17,15 @@ def copytree(src, dst, symlinks=False, ignore=None):
             shutil.copy2(s, d)
 
 def replace_define(field, value):
-	for define in env['CPPDEFINES']:
-		if define[0] == field:
-			env['CPPDEFINES'].remove(define)
-	env['CPPDEFINES'].append((field, value))
+    to_remove = []
+    for define in env['CPPDEFINES']:
+        if define[0] == field:
+            to_remove.append(define)
+    
+    for define in to_remove:
+        env['CPPDEFINES'].remove(define)
+    
+    env['CPPDEFINES'].append((field, value))
 
 # Relocate the firmware to a new address, such as "0x08005000"
 def relocate_firmware(address):

--- a/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/buildroot/share/PlatformIO/scripts/stm32_bootloader.py
+++ b/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/buildroot/share/PlatformIO/scripts/stm32_bootloader.py
@@ -20,6 +20,8 @@ def noencrypt(source, target, env):
 if 'offset' in board.get("build").keys():
 	LD_FLASH_OFFSET = board.get("build.offset")
 	marlin.relocate_vtab(LD_FLASH_OFFSET)
+	# echo out the value of build.offset
+	print("LD_FLASH_OFFSET: " + LD_FLASH_OFFSET)
 
 	# Flash size
 	maximum_flash_size = int(board.get("upload.maximum_size") / 1024)

--- a/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/ini/stm32f1-maple.ini
+++ b/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/ini/stm32f1-maple.ini
@@ -101,7 +101,8 @@ upload_protocol   = serial
 [env:STM32F103RC_btt_maple]
 platform             = ${common_stm32f1.platform}
 extends              = common_STM32F103RC_maple
-board_build.address  = 0x08007000
+#board_build.address  = 0x08007000
+board_build.address   = 0x08000000
 board_build.ldscript = STM32F103RC_SKR_MINI_256K.ld
 extra_scripts        = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/custom_board.py
@@ -109,6 +110,10 @@ build_flags          = ${common_stm32f1.build_flags}
   -DDEBUG_LEVEL=0 -DSS_TIMER=4
 custom_marlin.NEOPIXEL_LED = Adafruit NeoPixel=https://github.com/bigtreetech/Adafruit_NeoPixel
 monitor_speed        = 115200
+upload_flags = -c 
+              adapter speed 1000
+              -c
+              reset_config srst_only srst_nogate connect_assert_srst
 
 [env:STM32F103RC_btt_USB_maple]
 platform          = ${common_stm32f1.platform}

--- a/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/ini/stm32f1.ini
+++ b/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/ini/stm32f1.ini
@@ -90,10 +90,12 @@ monitor_speed     = 115200
 platform             = ${common_stm32.platform}
 extends              = common_STM32F103RC
 build_flags          = ${common_stm32.build_flags} -DDEBUG_LEVEL=0 -DTIMER_SERVO=TIM5
-board_build.offset   = 0x7000
+#board_build.offset   = 0x7000
+board_build.offset   = 0x0000
 board_build.encrypt  = No
 board_build.firmware = firmware.bin
-board_upload.offset_address = 0x08007000
+#board_upload.offset_address = 0x08007000
+board_upload.offset_address = 0x08000000
 
 [env:STM32F103RC_btt_USB]
 extends           = env:STM32F103RC_btt

--- a/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/platformio.ini
+++ b/firmware/V2.0/Marlin-2.0.8.2.x-SKR-mini-E3-V2.0/platformio.ini
@@ -267,4 +267,4 @@ monitor_flags =
 platform    = atmelavr
 board       = megaatmega2560
 build_flags = -c -H -std=gnu++11 -Wall -Os -D__MARLIN_FIRMWARE__
-src_filter  = +<src/MarlinCore.cpp>
+build_src_filter  = +<src/MarlinCore.cpp>


### PR DESCRIPTION
Removed maple bootloader support.
Code loads at 0x08000000 instead of 0x08007000.
Can flash and debug with stlink debugger.
